### PR TITLE
Add test cases for log messages that contain crash reason

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir main-otp-27
+elixir 1.19.0-rc.0-otp-27

--- a/test/default_logger_test.exs
+++ b/test/default_logger_test.exs
@@ -92,6 +92,30 @@ defmodule LoggerHandlerKit.DefaultLoggerTest do
       assert_receive {^io_ref, msg}
       assert msg =~ "[info] Hello World"
     end
+
+    test "log with crash reason: exception", %{handler_ref: ref, io_ref: io_ref} do
+      LoggerHandlerKit.Act.log_with_crash_reason(:exception)
+      LoggerHandlerKit.Assert.assert_logged(ref)
+
+      assert_receive {^io_ref, msg}
+      assert msg =~ "[error] Handled Exception"
+    end
+
+    test "log with crash reason: throw", %{handler_ref: ref, io_ref: io_ref} do
+      LoggerHandlerKit.Act.log_with_crash_reason(:throw)
+      LoggerHandlerKit.Assert.assert_logged(ref)
+
+      assert_receive {^io_ref, msg}
+      assert msg =~ "[error] Caught"
+    end
+
+    test "log with crash reason: exit", %{handler_ref: ref, io_ref: io_ref} do
+      LoggerHandlerKit.Act.log_with_crash_reason(:exit)
+      LoggerHandlerKit.Assert.assert_logged(ref)
+
+      assert_receive {^io_ref, msg}
+      assert msg =~ "[error] Exited"
+    end
   end
 
   describe "OTP" do


### PR DESCRIPTION
TODO: check what libraries choose to report and this case and add it to the docs