### PR TITLE
Add `share_ownership_to` option to ownership filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ flowchart TD
 def deps do
   [
     # The package only makes sense for tests!
-    {:logger_handler_kit, only: :test, "~> 0.3.0"}
+    {:logger_handler_kit, only: :test, "~> 0.4.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LoggerHandlerKit.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @source_url "https://github.com/martosaur/logger_handler_kit"
 
   def project do


### PR DESCRIPTION
Currently, ownership filter does a great job figuring out if the logger process has a connection to test process. However, it only shares this with `Mox`. `Mox` runs by far the most popular ownership server, but it's hardly the only one. For example, `Req` also runs [its own](https://github.com/wojtekmach/req/blob/dcb7ddf6a449dfd2cc2a99c6354d050b65e5191a/lib/req/application.ex#L15) and [`Sentry` too](https://github.com/getsentry/sentry-elixir/blob/f83b5080aec61e0618b01efe14de28fce5e914b3/lib/sentry/test.ex#L373-L385).

To address this, ownership filter can accept list of ownership servers under `share_ownership_with` option, which is just `[{:global, Mox.Server}]` by default